### PR TITLE
Endpoint to delete comments

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -127,22 +127,23 @@ describe("NCNews API testing", () => {
     });
   });
   describe("GET/api/articles/:article_id", () => {
-    test("return correct article when passed an article id ", () => {
+    test.only("return correct article when passed an article id ", () => {
       return request(app)
-        .get("/api/articles/2")
+        .get("/api/articles/1")
         .expect(200)
         .then(({ body }) => {
           expect(body).toEqual({
             articles: {
-              author: expect.any(String),
-              title: expect.any(String),
-              article_id: expect.any(Number),
-              body: expect.any(String),
-              topic: expect.any(String),
-              created_at: expect.any(String),
-              votes: expect.any(Number),
-              article_img_url: expect.any(String),
-              comment_count: expect.any(String),
+              article_id: 1,
+              title: "Living in the shadow of a great man",
+              topic: "mitch",
+              author: "butter_bridge",
+              body: "I find this existence challenging",
+              created_at: "2020-07-09T20:11:00.000Z",
+              votes: 100,
+              article_img_url:
+                "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700",
+              comment_count: "11",
             },
           });
           expect(Object.keys(body.articles)).toHaveLength(9);

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -369,5 +369,13 @@ describe("NCNews API testing", () => {
     test.only("deletes the comment when given and id and responds with status 204", () => {
       return request(app).delete("/api/comments/1").expect(204);
     });
+    test.only("After a comment is deleted we should expect a 404 error code as the comment shouldnt exist", () => {
+      return request(app)
+        .get("/api/comments/1")
+        .expect(404)
+        .then((response) => {
+          expect(response.body.msg).toBe("URL not found");
+        });
+    });
   });
 });

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -127,7 +127,7 @@ describe("NCNews API testing", () => {
     });
   });
   describe("GET/api/articles/:article_id", () => {
-    test.only("return correct article when passed an article id ", () => {
+    test("return correct article when passed an article id ", () => {
       return request(app)
         .get("/api/articles/1")
         .expect(200)
@@ -363,6 +363,11 @@ describe("NCNews API testing", () => {
         .then(({ body }) => {
           expect(body.msg).toBe("URL not found");
         });
+    });
+  });
+  describe("DELETE/api/comments/id", () => {
+    test.only("deletes the comment when given and id and responds with status 204", () => {
+      return request(app).delete("/api/comments/1").expect(204);
     });
   });
 });

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -154,7 +154,7 @@ describe("NCNews API testing", () => {
         .get("/api/articles/4311462")
         .expect(404)
         .then(({ body }) => {
-          expect(body.msg).toBe("Article not found");
+          expect(body.msg).toBe("Article 4311462 was not found");
         });
     });
   });
@@ -199,7 +199,7 @@ describe("NCNews API testing", () => {
         .get("/api/articles/98/comments")
         .expect(404)
         .then(({ body }) => {
-          expect(body.msg).toBe("Article not found");
+          expect(body.msg).toBe("Article 98 was not found");
         });
     });
   });
@@ -246,7 +246,7 @@ describe("NCNews API testing", () => {
         .send(newComment)
         .expect(404)
         .then((response) => {
-          expect(response.body.msg).toBe("Article not found");
+          expect(response.body.msg).toBe("Article 5256261 was not found");
         });
     });
     test("returns 'Bad request' for comments with wrong keys i.e not username/body", () => {
@@ -325,7 +325,7 @@ describe("NCNews API testing", () => {
         .send({ inc_votes: 20 })
         .expect(404)
         .then((res) => {
-          expect(res.body.msg).toBe("Article not found");
+          expect(res.body.msg).toBe("Article 42152 was not found");
         });
     });
     test("returns 'Bad Request' and the status code 400 for an invalid paths", () => {

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -374,7 +374,7 @@ describe("NCNews API testing", () => {
           expect(response.noContent).toBe(true);
         });
     });
-    test("After a comment is deleted we should expect a 404 error code as the comment shouldnt exist", () => {
+    test("after a comment is deleted we should expect a 404 error code as the comment shouldn't exist", () => {
       return request(app)
         .get("/api/comments/1")
         .expect(404)
@@ -387,8 +387,15 @@ describe("NCNews API testing", () => {
         .delete("/api/comments/412")
         .expect(404)
         .then((response) => {
-          console.log(response);
           expect(response.body.msg).toBe(`Comment 412 was not found`);
+        });
+    });
+    test("returns 'Bad Request' when trying to delete with a word instead of a number", () => {
+      return request(app)
+        .delete("/api/comments/dawnblade")
+        .expect(400)
+        .then((response) => {
+          expect(response.body.msg).toBe(`Bad Request`);
         });
     });
   });

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -129,23 +129,23 @@ describe("NCNews API testing", () => {
   describe("GET/api/articles/:article_id", () => {
     test("return correct article when passed an article id ", () => {
       return request(app)
-        .get("/api/articles/1")
+        .get("/api/articles/2")
         .expect(200)
         .then(({ body }) => {
           expect(body).toEqual({
             articles: {
-              article_id: 1,
-              title: "Living in the shadow of a great man",
-              topic: "mitch",
-              author: "butter_bridge",
-              body: "I find this existence challenging",
-              created_at: "2020-07-09T20:11:00.000Z",
-              votes: 100,
-              article_img_url:
-                "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700",
+              author: expect.any(String),
+              title: expect.any(String),
+              article_id: expect.any(Number),
+              body: expect.any(String),
+              topic: expect.any(String),
+              created_at: expect.any(String),
+              votes: expect.any(Number),
+              article_img_url: expect.any(String),
+              comment_count: expect.any(String),
             },
           });
-          expect(Object.keys(body.articles)).toHaveLength(8);
+          expect(Object.keys(body.articles)).toHaveLength(9);
         });
     });
     test("for articles with non existent ids we should expect a 404 error", () => {

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -382,5 +382,13 @@ describe("NCNews API testing", () => {
           expect(response.body.msg).toBe("URL not found");
         });
     });
+    test.only("returns 'Bad request' when you try to delete with wrong data type", () => {
+      return request(app)
+        .delete("/api/comments/vegeta")
+        .expect(400)
+        .then((response) => {
+          expect(response.body.msg).toBe("Bad Request");
+        });
+    });
   });
 });

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -366,10 +366,15 @@ describe("NCNews API testing", () => {
     });
   });
   describe("DELETE/api/comments/id", () => {
-    test.only("deletes the comment when given and id and responds with status 204", () => {
-      return request(app).delete("/api/comments/1").expect(204);
+    test("deletes the comment when given and id and responds with status 204", () => {
+      return request(app)
+        .delete("/api/comments/1")
+        .expect(204)
+        .then((response) => {
+          expect(response.noContent).toBe(true);
+        });
     });
-    test.only("After a comment is deleted we should expect a 404 error code as the comment shouldnt exist", () => {
+    test("After a comment is deleted we should expect a 404 error code as the comment shouldnt exist", () => {
       return request(app)
         .get("/api/comments/1")
         .expect(404)

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -382,12 +382,13 @@ describe("NCNews API testing", () => {
           expect(response.body.msg).toBe("URL not found");
         });
     });
-    test.only("returns 'Bad request' when you try to delete with wrong data type", () => {
+    test("returns 'Comment not found' when you try to delete a non existent comment", () => {
       return request(app)
-        .delete("/api/comments/vegeta")
-        .expect(400)
+        .delete("/api/comments/412")
+        .expect(404)
         .then((response) => {
-          expect(response.body.msg).toBe("Bad Request");
+          console.log(response);
+          expect(response.body.msg).toBe(`Comment 412 was not found`);
         });
     });
   });

--- a/app/app.js
+++ b/app/app.js
@@ -9,6 +9,7 @@ const {
   addComment,
   updateVotes,
   getAllUsers,
+  removeComment,
 } = require("../controllers/controllers");
 app.use(express.json());
 
@@ -19,6 +20,7 @@ app.get("/api/articles/:article_id/comments", getComments);
 app.post("/api/articles/:article_id/comments", addComment);
 app.patch("/api/articles/:article_id", updateVotes);
 app.get("/api/users", getAllUsers);
+app.delete("/api/comments/:comment_id", removeComment);
 
 app.use((error, request, response, next) => {
   if (error.status) {

--- a/controllers/controllers.js
+++ b/controllers/controllers.js
@@ -90,8 +90,8 @@ exports.getAllUsers = (request, response, next) => {
 exports.removeComment = (request, response, next) => {
   const { comment_id } = request.params;
   deleteComment(comment_id)
-    .then((comment) => {
-      response.status(204).send({ comment });
+    .then(() => {
+      response.status(204).send();
     })
     .catch(next);
 };

--- a/controllers/controllers.js
+++ b/controllers/controllers.js
@@ -8,6 +8,7 @@ const {
   fetchUsers,
   fetchQuery,
   deleteComment,
+  fetchCommentsByID,
 } = require("../models/models");
 
 exports.getAllTopics = (request, response, next) => {
@@ -89,9 +90,11 @@ exports.getAllUsers = (request, response, next) => {
 
 exports.removeComment = (request, response, next) => {
   const { comment_id } = request.params;
-  deleteComment(comment_id)
+  fetchCommentsByID(comment_id)
     .then(() => {
-      response.status(204).send();
+      deleteComment(comment_id).then(() => {
+        response.status(204).send();
+      });
     })
     .catch(next);
 };

--- a/controllers/controllers.js
+++ b/controllers/controllers.js
@@ -7,6 +7,7 @@ const {
   alterVotes,
   fetchUsers,
   fetchQuery,
+  deleteComment,
 } = require("../models/models");
 
 exports.getAllTopics = (request, response, next) => {
@@ -84,4 +85,13 @@ exports.getAllUsers = (request, response, next) => {
     .catch((error) => {
       next(error);
     });
+};
+
+exports.removeComment = (request, response, next) => {
+  const { comment_id } = request.params;
+  deleteComment(comment_id)
+    .then((comment) => {
+      response.status(204).send({ comment });
+    })
+    .catch(next);
 };

--- a/models/models.js
+++ b/models/models.js
@@ -50,7 +50,10 @@ exports.fetchArticlesByID = (article_id) => {
   GROUP BY articles.article_id ORDER BY articles.created_at DESC`;
   return db.query(query, [article_id]).then(({ rows, rowCount }) => {
     if (rowCount === 0) {
-      return Promise.reject({ status: 404, msg: "Article not found" });
+      return Promise.reject({
+        status: 404,
+        msg: `Article ${article_id} was not found`,
+      });
     }
     return rows[0];
   });

--- a/models/models.js
+++ b/models/models.js
@@ -45,7 +45,9 @@ exports.fetchArticles = (topic, sort_by = "created_at", order = "desc") => {
 };
 
 exports.fetchArticlesByID = (article_id) => {
-  const query = `SELECT * FROM articles WHERE articles.article_id =$1`;
+  const query = `SELECT articles.* , COUNT(comments.article_id) AS comment_count FROM articles 
+  LEFT JOIN comments ON articles.article_id = comments.article_id WHERE articles.article_id = $1
+  GROUP BY articles.article_id ORDER BY articles.created_at DESC`;
   return db.query(query, [article_id]).then(({ rows, rowCount }) => {
     if (rowCount === 0) {
       return Promise.reject({ status: 404, msg: "Article not found" });

--- a/models/models.js
+++ b/models/models.js
@@ -92,3 +92,13 @@ exports.fetchUsers = () => {
     return users;
   });
 };
+
+exports.deleteComment = (comment_id) => {
+  return db
+    .query(`DELETE FROM comments WHERE comment_id = $1 RETURNING *;`, [
+      comment_id,
+    ])
+    .then(({ rows }) => {
+      return rows;
+    });
+};

--- a/models/models.js
+++ b/models/models.js
@@ -102,3 +102,16 @@ exports.deleteComment = (comment_id) => {
       return rows;
     });
 };
+
+exports.fetchCommentsByID = (comment_id) => {
+  const deleteQuery = `SELECT * FROM comments WHERE comment_id = $1`;
+  return db.query(deleteQuery, [comment_id]).then((result) => {
+    if (result.rows.length === 0) {
+      return Promise.reject({
+        status: 404,
+        msg: `Comment ${comment_id} was not found`,
+      });
+    }
+    return result.rows;
+  });
+};


### PR DESCRIPTION
Did Task 11 and 12 on the same branch since Task 11 was similar to Task 4. Added a comment count property for articles aswell as an endpoint to delete comments.

Added an extra model to fetch for comment ids before deleting them , which  allows for two different error messages either "Comment not found" if the id is not present or  "URL not found" if its been deleted.